### PR TITLE
Use zcash-params instead of zcashplus-params

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2014 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
@@ -480,13 +481,13 @@ static boost::filesystem::path ZC_GetBaseParamsDir()
     // Copied from GetDefaultDataDir and adapter for zcash params.
 
     namespace fs = boost::filesystem;
-    // Windows < Vista: C:\Documents and Settings\Username\Application Data\ZcashPlusParams
-    // Windows >= Vista: C:\Users\Username\AppData\Roaming\ZcashPlusParams
-    // Mac: ~/Library/Application Support/ZcashPlusParams
-    // Unix: ~/.zcashplus-params
+    // Windows < Vista: C:\Documents and Settings\Username\Application Data\ZcashParams
+    // Windows >= Vista: C:\Users\Username\AppData\Roaming\ZcashParams
+    // Mac: ~/Library/Application Support/ZcashParams
+    // Unix: ~/.zcash-params
 #ifdef WIN32
     // Windows
-    return GetSpecialFolderPath(CSIDL_APPDATA) / "ZcashPlusParams";
+    return GetSpecialFolderPath(CSIDL_APPDATA) / "ZcashParams";
 #else
     fs::path pathRet;
     char* pszHome = getenv("HOME");
@@ -498,10 +499,10 @@ static boost::filesystem::path ZC_GetBaseParamsDir()
     // Mac
     pathRet /= "Library/Application Support";
     TryCreateDirectory(pathRet);
-    return pathRet / "ZcashPlusParams";
+    return pathRet / "ZcashParams";
 #else
     // Unix
-    return pathRet / ".zcashplus-params";
+    return pathRet / ".zcash-params";
 #endif
 #endif
 }

--- a/zcutil/fetch-params.sh
+++ b/zcutil/fetch-params.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-PARAMS_DIR="$HOME/.zcashplus-params"
+PARAMS_DIR="$HOME/.zcash-params"
 
 SPROUT_PKEY_NAME='sprout-proving.key'
 SPROUT_VKEY_NAME='sprout-verifying.key'


### PR DESCRIPTION
No need for another copy of the zcash params for those that already have zcash, zen, zclassic, etc.